### PR TITLE
Fix WVP transient drawdown model

### DIFF
--- a/productiecapaciteit/src/strang_analyse_fun2.py
+++ b/productiecapaciteit/src/strang_analyse_fun2.py
@@ -116,6 +116,7 @@ def get_rules(exclude_rules=[], include_rules=[]):
     ]
 
     if include_rules:
+        assert exclude_rules == [], "Cannot use both include_rules and exclude_rules"
         rules = [r for r in rules if r[0] in include_rules]
 
     if exclude_rules:

--- a/productiecapaciteit/src/wvp_transient.py
+++ b/productiecapaciteit/src/wvp_transient.py
@@ -3,12 +3,8 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from dawacotools import get_daw_ts_meteo
-from scipy import linalg
-from scipy.optimize import least_squares
-from scipy.stats import hmean
-from wvp_transient_funs import dis, objective
 
+from productiecapaciteit import data_dir, results_dir
 from productiecapaciteit.src.strang_analyse_fun2 import (
     get_config,
     get_false_measurements,
@@ -18,115 +14,198 @@ from productiecapaciteit.src.weerstand_pandasaccessors import (
     WellResistanceAccessor,  # noqa: F401
     WvpResistanceAccessor,  # noqa: F401
 )
-
-data_fd = os.path.join("..", "data")
-config_fn = "strang_props6.xlsx"
-config = get_config(os.path.join(data_fd, config_fn))
-
-r = 0.6
-kD0 = 200.0  # m/d2 at reference temperature
-c = 50.0  # d
-S = 0.2
-
-strang = "Q200"  # "IK102"
-ci = config.loc[strang]
-
-# get observations
-df_fp = os.path.join(data_fd, "Merged", f"{strang}-PKA-DSEW036680.feather")
-df = pd.read_feather(df_fp)
-df["Datum"] = pd.to_datetime(df["Datum"])
-df.set_index("Datum", inplace=True)
-include_rules = ["Unrealistic flow"]
-untrusted_measurements = get_false_measurements(df, ci, extend_hours=1, include_rules=include_rules)
-df = df.loc[~np.array(untrusted_measurements)]
-df = df.loc[~np.isnan(df.Q)]
-dfm = df.resample("12h", label="right").mean()
-dfm = dfm.loc[~np.isnan(dfm.Q)]
-
-# get initial estimates
-filterweerstand_fp = os.path.join("..", "results", "Filterweerstand", "Filterweerstand_modelcoefficienten.xlsx")
-wvpweerstand_fp = os.path.join("..", "results", "Wvpweerstand", "Wvpweerstand_modelcoefficienten.xlsx")
-df_a_wvp = pd.read_excel(wvpweerstand_fp, sheet_name=strang, index_col=0).squeeze("columns")
-
-
-# initial, lower limit, upper limit
-params = {
-    "alpha": [(r**2 * S / 4) ** 0.5, 0.0, 100 * (r**2 * S / 4) ** 0.5],
-    "beta": [(1 / (c * S)) ** 0.5, 0.0, (1 / (c * S)) ** 0.5],
-    "kD0": [140.0, 50.0, 500.0],
-    "time_delta": [df_a_wvp.temp_delta, 0.0, 10.0],
-    "temp_time_offset": [df_a_wvp.time_offset, 31 + 2 * 20, 365],
-    # alpha_multi=[(1**2 * S / 4) ** 0.5, 0.0, 100 * (1**2 * S / 4) ** 0.5],
-    "alpha_multi": [2.7, 0.1, 25.0],
-}
-
-dx_put = ci.dx_tussenputten
-dx_mirrorwell = ci.dx_mirrorwell  # [li for li in pd.eval(ci.dx_mirrorwell) if li[1] < 200]
-nput_model = 15
-
-multiwell = (
-    [(li[0], 2 * li[1]) for li in dx_mirrorwell]
-    + [(2, i * dx_put) for i in range(1, nput_model + 1)]
-    + [(li[0], 2 * dis(i * dx_put, 2 * li[1])) for li in dx_mirrorwell for i in range(1, nput_model + 1)]
-)
-ds_rain = get_daw_ts_meteo("235", "Neerslag")
-pextra = {
-    "index": dfm.index.values[:-1],
-    "drawdown_obs": (dfm.pandpeil - dfm.gws0).values[:-1],
-    "Q_obs": dfm.Q.values[1:] / ci.nput,
-    "temp_ref": dfm.gwt0.median(),
-    "dt_lower": pd.Timedelta(value=hmean(np.diff(dfm.index) / pd.Timedelta(1, unit="D")), unit="D"),
-    "multiwell_contains_r_self": False,
-    "multiwell": multiwell,
-    # rain=np.interp(dfm.index[1:], ds_rain.index, ds_rain),
-    "frac_step_max": 0.95,
-}
-assert np.isnan(pextra["Q_obs"]).sum() == 0
-
-args = [i[0] for i in params.values()]
-
-res = least_squares(
+from productiecapaciteit.src.wvp_transient_funs import (
+    build_multiwell_geometry,
+    infer_lower_timestep,
     objective,
-    x0=[i[0] for i in params.values()],
-    bounds=([i[1] for i in params.values()], [i[2] for i in params.values()]),
-    # loss="arctan",
-    f_scale=0.5,
-    kwargs=pextra,
 )
 
 
-def get_perr(res):
-    if np.any(res.active_mask):
-        print(f"{res.active_mask} True for params at bounds")
-    U, s, Vh = linalg.svd(res.jac, full_matrices=False)
-    tol = np.finfo(float).eps * s[0] * max(res.jac.shape)
-    w = s > tol
-    cov = (Vh[w].T / s[w] ** 2) @ Vh[w]  # robust covariance matrix
-    chi2dof = np.sum(res.fun**2) / (res.fun.size - res.x.size)
-    cov *= chi2dof
-    perr = np.sqrt(np.diag(cov))
-    perr_rel = perr / res.x
+CONFIG_FN = "strang_props7.csv"
+STRANG = "IK102"
 
-    sl = []
-    for xi, perr_ri in zip(res.x, perr_rel, strict=False):
-        sl.append(f"{xi} +/- {perr_ri * 100:.1f}%")
+HOURS_PER_DAY = 24.0
 
-    print("\n".join(sl))
-    return perr
+# Hantush parameters are expressed in days and meters. Flow measurements in this
+# repository are m3/h, so the forcing is converted to m3/d before modelling.
+WELL_RADIUS_M = 0.6
+KD0_M2_PER_D = 200.0
+LEAKAGE_RESISTANCE_D = 50.0
+STORAGE_COEFFICIENT = 0.2
+
+RESAMPLE_FREQUENCY = "12h"
+BAD_DATA_RULES = ["Unrealistic flow"]
+
+# None selects one of the center wells. Set a zero-based index for a specific
+# well if the observation point is known.
+TARGET_WELL_INDEX = None
 
 
-perr = get_perr(res)
-a = objective(res.x, return_result=True, **pextra)
-plt.plot(pextra["index"], pextra["drawdown_obs"])
-plt.plot(pextra["index"], a)
+def load_wvp_coefficients(strang):
+    wvpweerstand_fp = results_dir / "Wvpweerstand" / "Wvpweerstand_modelcoefficienten.xlsx"
+    return pd.read_excel(wvpweerstand_fp, sheet_name=strang, index_col=0).squeeze("columns")
 
-"""
-0.11959938975024936 +/- 121.1%
-0.3798944820153483 +/- 6.6%
-179.63725616239432 +/- 59.3%
-6.058479229670381 +/- 5.5%
-176.36014752388652 +/- 0.9%
-0.16542716576149427 +/- 44.2%
-"""
-# a = objective((alpha, beta, kD0, temp_delta, temp_time_offset))
-print("hoi")
+
+def load_filter_coefficients(strang):
+    filterweerstand_fp = results_dir / "Filterweerstand" / "Filterweerstand_modelcoefficienten.xlsx"
+    return pd.read_excel(filterweerstand_fp, sheet_name=strang)
+
+
+def load_observations(strang, ci):
+    df_fp = os.path.join(data_dir, "Merged", f"{strang}.feather")
+    df = pd.read_feather(df_fp)
+    df["Datum"] = pd.to_datetime(df["Datum"])
+    df.set_index("Datum", inplace=True)
+
+    untrusted_measurements = get_false_measurements(
+        df,
+        ci,
+        extend_hours=1,
+        include_rules=BAD_DATA_RULES,
+    )
+    df = df.loc[~np.asarray(untrusted_measurements)].copy()
+    df = df.loc[np.isfinite(df.Q)]
+
+    dfm = df.resample(RESAMPLE_FREQUENCY, label="right").mean()
+    dfm = dfm.loc[np.isfinite(dfm.Q)].copy()
+    if dfm.empty:
+        raise ValueError(f"No finite flow observations remain for {strang}")
+    return dfm
+
+
+def add_aquifer_drawdown_observations(dfm, ci, df_a_filter):
+    q_per_well_m3h = dfm.Q / ci.nput
+    p_omstorting_reconstructed = dfm.gws0 - df_a_filter.wel.dp_model(dfm.index, q_per_well_m3h)
+    dfm["p_omstorting"] = dfm.gws1.where(dfm.gws1.notna(), p_omstorting_reconstructed)
+    dfm["drawdown_aquifer"] = dfm.pandpeil - dfm.p_omstorting
+
+    valid_drawdown = np.isfinite(dfm.drawdown_aquifer)
+    if valid_drawdown.sum() == 0:
+        raise ValueError("No finite aquifer drawdown observations are available")
+    if np.nanmedian(dfm.drawdown_aquifer) <= 0.0:
+        raise ValueError(
+            "Median aquifer drawdown is not positive; check head columns and sign convention"
+        )
+    return dfm
+
+
+def build_pextra(dfm, ci):
+    multiwell, multiwell_counts = build_multiwell_geometry(
+        ci.dx_tussenputten,
+        ci.dx_mirrorwell,
+        ci.nput,
+        target_well_index=TARGET_WELL_INDEX,
+        distance_scale=1.0 / WELL_RADIUS_M,
+        include_self=True,
+        self_distance=1.0,
+    )
+
+    q_obs_m3d_per_well = dfm.Q.to_numpy(dtype=float) / ci.nput * HOURS_PER_DAY
+    if not np.isfinite(q_obs_m3d_per_well).all():
+        raise ValueError("Q_obs contains NaN or infinite values")
+
+    temp_ref = float(dfm.gwt0.median())
+    if not np.isfinite(temp_ref):
+        raise ValueError("Cannot determine finite reference groundwater temperature")
+
+    return {
+        "index": dfm.index,
+        "drawdown_obs": dfm.drawdown_aquifer.to_numpy(dtype=float),
+        "Q_obs": q_obs_m3d_per_well,
+        "temp_ref": temp_ref,
+        "dt_lower": infer_lower_timestep(dfm.index),
+        "multiwell_contains_r_self": True,
+        "multiwell": multiwell,
+        "multiwell_counts": multiwell_counts,
+        "log_multiwell": False,
+        "frac_step_max": 0.95,
+        "initial_condition": "steady",
+        "tmax_days_cap": None,
+    }
+
+
+def get_initial_params(df_a_wvp):
+    alpha = (WELL_RADIUS_M**2 * STORAGE_COEFFICIENT / 4.0) ** 0.5
+    beta = (1.0 / (LEAKAGE_RESISTANCE_D * STORAGE_COEFFICIENT)) ** 0.5
+    return [
+        alpha,
+        beta,
+        KD0_M2_PER_D,
+        df_a_wvp.temp_delta,
+        df_a_wvp.time_offset,
+    ]
+
+
+def get_single_well_pextra(pextra):
+    return {
+        **pextra,
+        "multiwell": [(1.0, 1.0)],
+        "multiwell_counts": {
+            "self_wells": 1,
+            "neighbor_well_terms": 0,
+            "neighbor_wells": 0,
+            "self_mirrorwell_terms": 0,
+            "self_mirrorwells": 0,
+            "neighbor_mirrorwell_terms": 0,
+            "neighbor_mirrorwells": 0,
+        },
+    }
+
+
+def plot_result(index, drawdown_obs, drawdown_multiwell, drawdown_single_well, strang):
+    fig, ax = plt.subplots()
+    ax.plot(index, drawdown_obs, label="observed aquifer drawdown")
+    ax.plot(index, drawdown_multiwell, label="multiwell + image wells")
+    ax.plot(index, drawdown_single_well, label="single well")
+    ax.set_ylabel("Drawdown (m)")
+    ax.legend()
+    fig.tight_layout()
+
+    output_dir = results_dir / "Wvpweerstand_transient"
+    output_dir.mkdir(exist_ok=True, parents=True)
+    output_fp = output_dir / f"wvp_transient_{strang}.png"
+    fig.savefig(output_fp, dpi=300)
+    plt.close(fig)
+    return output_fp
+
+
+def main():
+    config = get_config(CONFIG_FN)
+    ci = config.loc[STRANG]
+
+    df_a_wvp = load_wvp_coefficients(STRANG)
+    df_a_filter = load_filter_coefficients(STRANG)
+    dfm = load_observations(STRANG, ci)
+    dfm = add_aquifer_drawdown_observations(dfm, ci, df_a_filter)
+    pextra = build_pextra(dfm, ci)
+
+    args = get_initial_params(df_a_wvp)
+
+    single_well_pextra = {**get_single_well_pextra(pextra), "log_multiwell": True}
+    multiwell_pextra = {**pextra, "log_multiwell": True}
+
+    drawdown_single_well = objective(args, return_result=True, **single_well_pextra)
+    drawdown_multiwell = objective(args, return_result=True, **multiwell_pextra)
+    drawdown_obs = pextra["drawdown_obs"]
+
+    if drawdown_single_well.shape != drawdown_multiwell.shape:
+        raise ValueError("Single-well and multiwell model outputs have different shapes")
+    if drawdown_multiwell.shape != drawdown_obs.shape:
+        raise ValueError("Modeled drawdown and observed drawdown have different shapes")
+    if not np.isfinite(drawdown_single_well).all():
+        raise ValueError("Single-well model contains NaN or infinite values")
+    if not np.isfinite(drawdown_multiwell).all():
+        raise ValueError("Multiwell model contains NaN or infinite values")
+
+    output_fp = plot_result(
+        pextra["index"],
+        drawdown_obs,
+        drawdown_multiwell,
+        drawdown_single_well,
+        STRANG,
+    )
+    print(f"Saved transient WVP drawdown plot to {output_fp}")
+
+
+if __name__ == "__main__":
+    main()

--- a/productiecapaciteit/src/wvp_transient_funs.py
+++ b/productiecapaciteit/src/wvp_transient_funs.py
@@ -1,18 +1,26 @@
-import asyncio
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import pandas as pd
 from scipy.special import k0, lambertw
+from scipy import linalg
 
 
 def get_temp(index, mean, delta, time_offset, return_series=False):
     index_datetime = pd.DatetimeIndex(index)
     year = pd.Categorical(index_datetime.year, ordered=True)
     start_year = year.rename_categories(pd.to_datetime(year.categories, format="%Y"))
-    end_year = year.rename_categories(pd.to_datetime(year.categories.astype(str) + "1231", format="%Y%m%d"))
-    nday_year = end_year.map(lambda x: x.dayofyear).astype(float)
+    end_year = year.rename_categories(
+        pd.to_datetime(year.categories.astype(str) + "1231", format="%Y%m%d")
+    )
+    nday_year = end_year.map(lambda x: x.dayofyear, na_action="ignore").astype(float)
     dt_year = index_datetime - start_year.to_numpy()
-    temp_data = delta * np.sin((dt_year / pd.Timedelta("1D") - time_offset) * 2 * np.pi / nday_year) + mean
+    temp_data = (
+        delta
+        * np.sin((dt_year / pd.Timedelta("1D") - time_offset) * 2 * np.pi / nday_year)
+        + mean
+    )
     if return_series:
         return pd.Series(data=temp_data, index=index_datetime, name="wvp_model_temp")
     return temp_data.values
@@ -28,6 +36,149 @@ def dis(dis1, dis2):
     return (dis1 * dis1 + dis2 * dis2) ** 0.5
 
 
+def as_float_array(name, values, size=None):
+    arr = np.asarray(values, dtype=float)
+    if arr.ndim == 0:
+        if size is None:
+            return arr.reshape(1)
+        return np.full(size, float(arr), dtype=float)
+    if arr.ndim != 1:
+        raise ValueError(f"{name} must be a scalar or 1D array, got shape {arr.shape}")
+    if size is not None and arr.size != size:
+        raise ValueError(f"{name} must have length {size}, got {arr.size}")
+    if not np.isfinite(arr).all():
+        raise ValueError(f"{name} contains NaN or infinite values")
+    return arr
+
+
+def infer_lower_timestep(index):
+    index = pd.DatetimeIndex(index)
+    if index.size < 2:
+        raise ValueError("index must contain at least two timestamps")
+    dt_days = np.diff(index) / pd.Timedelta(1, unit="D")
+    dt_days = dt_days[np.isfinite(dt_days) & (dt_days > 0.0)]
+    if dt_days.size == 0:
+        raise ValueError("index must be strictly increasing")
+    return pd.Timedelta(float(dt_days.min()), unit="D")
+
+
+def build_multiwell_geometry(
+    dx_put,
+    dx_mirrorwell,
+    nput,
+    *,
+    target_well_index=None,
+    distance_scale=1.0,
+    include_self=True,
+    self_distance=1.0,
+):
+    """Build finite-row real-well and image-well terms for the transient model.
+
+    Parameters
+    ----------
+    dx_put : float
+        Distance between neighboring real wells along the row, in meters.
+    dx_mirrorwell : iterable
+        Image-well specs from the config as ``(multiplicity, canal_distance_m)``.
+        Negative multiplicities represent opposite-sign image wells for
+        constant-head canal boundaries.
+    nput : int
+        Number of real wells in the row.
+    target_well_index : int, optional
+        Zero-based target well index. If omitted, one of the center wells is used.
+    distance_scale : float, default 1.0
+        Factor applied to all physical distances. Use ``1 / well_radius`` when
+        passing the result to ``objective(..., multiwell_contains_r_self=True)``.
+    include_self : bool, default True
+        Include the target well itself as the first term.
+    self_distance : float, default 1.0
+        Distance assigned to the target well when ``include_self`` is true.
+        For normalized distances this is one well radius.
+
+    Returns
+    -------
+    list[tuple[float, float]], dict
+        Multiwell terms ``(multiplicity, scaled_distance)`` and diagnostic counts.
+    """
+    dx_put = float(dx_put)
+    if dx_put <= 0.0:
+        raise ValueError(f"dx_put must be positive, got {dx_put}")
+
+    nput_float = float(nput)
+    nput_int = int(round(nput_float))
+    if nput_int < 1 or not np.isclose(nput_float, nput_int):
+        raise ValueError(f"nput must be a positive integer, got {nput}")
+
+    if target_well_index is None:
+        target_well_index = nput_int // 2
+    target_well_index = int(target_well_index)
+    if target_well_index < 0 or target_well_index >= nput_int:
+        raise ValueError(
+            f"target_well_index must be in [0, {nput_int - 1}], got {target_well_index}"
+        )
+
+    distance_scale = float(distance_scale)
+    if distance_scale <= 0.0:
+        raise ValueError(f"distance_scale must be positive, got {distance_scale}")
+
+    neighbor_counts = defaultdict(int)
+    for well_index in range(nput_int):
+        if well_index == target_well_index:
+            continue
+        row_distance = abs(well_index - target_well_index) * dx_put
+        neighbor_counts[row_distance] += 1
+    neighbor_items = sorted(neighbor_counts.items())
+
+    if dx_mirrorwell is None:
+        image_specs = []
+    else:
+        image_arr = np.asarray(dx_mirrorwell, dtype=float)
+        if image_arr.size == 0:
+            image_specs = []
+        else:
+            image_arr = np.atleast_2d(image_arr)
+            if image_arr.shape[1] != 2:
+                raise ValueError(
+                    "dx_mirrorwell must contain (multiplicity, canal_distance_m) pairs"
+                )
+            image_specs = [(float(multi), float(distance)) for multi, distance in image_arr]
+
+    multiwell = []
+    if include_self:
+        multiwell.append((1.0, float(self_distance)))
+
+    for row_distance, count in neighbor_items:
+        multiwell.append((float(count), row_distance * distance_scale))
+
+    for image_multi, canal_distance in image_specs:
+        if canal_distance <= 0.0:
+            raise ValueError(f"Mirror-well canal distance must be positive, got {canal_distance}")
+        image_distance = 2.0 * canal_distance
+        if include_self:
+            multiwell.append((image_multi, image_distance * distance_scale))
+        for row_distance, count in neighbor_items:
+            multiwell.append(
+                (
+                    count * image_multi,
+                    dis(row_distance, image_distance) * distance_scale,
+                )
+            )
+
+    mirrorwell_multiplicity = sum(abs(multi) for multi, _ in image_specs)
+    counts = {
+        "self_wells": int(include_self),
+        "neighbor_well_terms": len(neighbor_items),
+        "neighbor_wells": nput_int - 1,
+        "self_mirrorwell_terms": len(image_specs) if include_self else 0,
+        "self_mirrorwells": mirrorwell_multiplicity if include_self else 0,
+        "neighbor_mirrorwell_terms": len(image_specs) * len(neighbor_items),
+        "neighbor_mirrorwells": mirrorwell_multiplicity * (nput_int - 1),
+        "target_well_index": target_well_index,
+        "nput": nput_int,
+    }
+    return multiwell, counts
+
+
 def objective(args, return_result=False, **pextra):
     """
     multialpha =
@@ -41,20 +192,43 @@ def objective(args, return_result=False, **pextra):
     -------
 
     """
+    if len(args) < 5:
+        raise ValueError("objective expects at least five parameters")
+
     alpha, beta, kD0, temp_delta, temp_time_offset = args[:5]
+    arg_idx = 5
     s = f"{alpha}, {beta}, {kD0}, {temp_delta}, {temp_time_offset}"
+    if alpha <= 0.0:
+        raise ValueError(f"alpha must be positive, got {alpha}")
+    if beta <= 0.0:
+        raise ValueError(f"beta must be positive, got {beta}")
+    if kD0 <= 0.0:
+        raise ValueError(f"kD0 must be positive, got {kD0}")
+    if not np.isfinite([temp_delta, temp_time_offset]).all():
+        raise ValueError("Temperature model parameters must be finite")
+
+    multiwell_contains_r_self = pextra.get("multiwell_contains_r_self", False)
+    alpha_multi = None
+    if pextra.get("multiwell") and not multiwell_contains_r_self:
+        if "alpha_multi" in pextra:
+            alpha_multi = pextra["alpha_multi"]
+        else:
+            if len(args) <= arg_idx:
+                raise ValueError(
+                    "objective needs alpha_multi when multiwell distances are not "
+                    "normalized by the self-well radius"
+                )
+            alpha_multi = args[arg_idx]
+            arg_idx += 1
+        s += f", {alpha_multi}"
+    elif not pextra.get("multiwell") and multiwell_contains_r_self:
+        raise ValueError("Define multiwell when multiwell_contains_r_self is True")
 
     if "rain" in pextra:
-        rain_gain, rain_timescale = args[-2:]
-        s += f", {rain_gain}, {rain_timescale}"
+        raise NotImplementedError("Rain response is not implemented in objective()")
 
-    if "multiwell" in pextra and not pextra["multiwell_contains_r_self"]:
-        alpha_multi = args[-3]
-        s += f", {alpha_multi}"
-    elif "multiwell" not in pextra and pextra["multiwell_contains_r_self"]:
-        assert 0, "Define multiwell"
-
-    print(s)
+    if len(args) != arg_idx:
+        raise ValueError(f"objective received {len(args)} parameters but consumed {arg_idx}")
 
     temp = get_temp(
         pextra["index"],
@@ -69,65 +243,81 @@ def objective(args, return_result=False, **pextra):
         multi, alpha, beta, kD = args
         return multi * hantush(alpha, beta, kD, **pextra)
 
-    if pextra["multiwell_contains_r_self"]:
-        grouper_list = []
+    hantush_args = []
 
+    if multiwell_contains_r_self:
         for multi, distance in pextra["multiwell"]:
-            grouper_list.append(
-                asyncio.get_event_loop().run_in_executor(
-                    None,
-                    multihantush,
-                    1,
-                    distance * alpha,
-                    beta,
-                    kD,
-                )
-            )
+            hantush_args.append((multi, distance * alpha, beta, kD))
     else:
-        grouper_list = [
-            asyncio.get_event_loop().run_in_executor(
-                None,
-                multihantush,
-                1,
-                alpha,
-                beta,
-                kD,
-            )
-        ]
+        hantush_args = [(1, alpha, beta, kD)]
 
         if pextra.get("multiwell"):
             for multi, distance in pextra["multiwell"]:
-                grouper_list.append(
-                    asyncio.get_event_loop().run_in_executor(
-                        None,
-                        multihantush,
-                        multi,
-                        distance * alpha_multi * alpha,
-                        beta,
-                        kD,
-                    )
-                )
+                hantush_args.append((multi, distance * alpha_multi * alpha, beta, kD))
 
     # if "rain" in pextra:
 
-    loop = asyncio.get_event_loop()
-    looper = asyncio.gather(*grouper_list)
-    results = loop.run_until_complete(looper)
+    if pextra.get("log_multiwell", False):
+        counts = pextra.get("multiwell_counts", {})
+        self_wells = counts.get("self_wells", 1)
+        neighbor_wells = counts.get("neighbor_wells", 0)
+        self_mirrorwells = counts.get("self_mirrorwells", 0)
+        neighbor_mirrorwells = counts.get("neighbor_mirrorwells", 0)
+        total_wells = self_wells + neighbor_wells
+        total_mirrorwells = self_mirrorwells + neighbor_mirrorwells
+        print(f"objective parameters: {s}")
+        print(
+            "multiwell setup: "
+            f"{total_wells} wells "
+            f"(self={self_wells}, neighboring={neighbor_wells}; "
+            f"neighbor terms={counts.get('neighbor_well_terms', 0)}), "
+            f"{total_mirrorwells} mirror wells "
+            f"(self mirrors={self_mirrorwells}, neighbor mirrors={neighbor_mirrorwells}; "
+            f"mirror terms={counts.get('self_mirrorwell_terms', 0) + counts.get('neighbor_mirrorwell_terms', 0)}), "
+            f"{len(hantush_args)} Hantush evaluations"
+        )
+
+    if len(hantush_args) == 1:
+        results = [multihantush(*hantush_args[0])]
+    else:
+        max_workers = pextra.get("max_workers", None)
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            results = list(executor.map(lambda args: multihantush(*args), hantush_args))
     drawdown_model = np.stack(results).sum(axis=0)
 
     if return_result:
         return drawdown_model
 
-    return np.square(
-        drawdown_model[~np.isnan(pextra["drawdown_obs"])] - pextra["drawdown_obs"][~np.isnan(pextra["drawdown_obs"])]
-    )
+    drawdown_obs = np.asarray(pextra["drawdown_obs"], dtype=float)
+    if drawdown_obs.shape != drawdown_model.shape:
+        raise ValueError(
+            f"drawdown_obs shape {drawdown_obs.shape} does not match model shape "
+            f"{drawdown_model.shape}"
+        )
+    valid_obs = np.isfinite(drawdown_obs)
+    if valid_obs.sum() == 0:
+        raise ValueError("drawdown_obs contains no finite values")
+    return drawdown_model[valid_obs] - drawdown_obs[valid_obs]
 
 
-def background(f):
-    def wrapped(*args, **kwargs):
-        return asyncio.get_event_loop().run_in_executor(None, f, *args, **kwargs)
+def get_perr(res):
+    if np.any(res.active_mask):
+        print(f"{res.active_mask} True for params at bounds")
+    U, s, Vh = linalg.svd(res.jac, full_matrices=False)
+    tol = np.finfo(float).eps * s[0] * max(res.jac.shape)
+    w = s > tol
+    cov = (Vh[w].T / s[w] ** 2) @ Vh[w]  # robust covariance matrix
+    chi2dof = np.sum(res.fun**2) / (res.fun.size - res.x.size)
+    cov *= chi2dof
+    perr = np.sqrt(np.diag(cov))
+    perr_rel = perr / res.x
 
-    return wrapped
+    sl = []
+    for xi, perr_ri in zip(res.x, perr_rel, strict=False):
+        sl.append(f"{xi} +/- {perr_ri * 100:.1f}%")
+
+    print("\n".join(sl))
+    return perr
 
 
 # @background
@@ -150,45 +340,96 @@ def hantush(alpha, beta, kD, **pextra):
     -------
 
     """
-    dQ = np.diff(pextra["Q_obs"], prepend=0.0)
-    rho = 2 * alpha * beta / np.sqrt(kD)
-    cS = 1 / np.square(beta)
+    index = pd.DatetimeIndex(pextra["index"])
+    nt = index.size
+    if nt < 2:
+        raise ValueError("index must contain at least two timestamps")
+    if not index.is_monotonic_increasing or not index.is_unique:
+        raise ValueError("index must be strictly increasing and unique")
 
-    # from pastas
-    tmax_val = min(365, max(lambertw(1 / ((1 - pextra["frac_step_max"]) * k0(rho))).real) * cS)
-    # print(f"tmax: {tmax_val:.1f} days")
+    alpha = float(alpha)
+    beta = float(beta)
+    if alpha <= 0.0:
+        raise ValueError(f"alpha must be positive, got {alpha}")
+    if beta <= 0.0:
+        raise ValueError(f"beta must be positive, got {beta}")
 
-    tmax = pd.Timedelta(
-        value=tmax_val,
-        unit="D",
-    )
+    q_obs = as_float_array("Q_obs", pextra["Q_obs"], nt)
+    kD = as_float_array("kD", kD, nt)
+    if np.any(kD <= 0.0):
+        raise ValueError("kD must be positive")
 
-    nt = pextra["index"].size
-    nt_max = min(np.ceil(tmax / pextra["dt_lower"]).astype(int), nt)
+    initial_condition = pextra.get("initial_condition", "steady")
+    if initial_condition == "steady":
+        initial_q = q_obs[0]
+    elif initial_condition == "zero":
+        initial_q = 0.0
+    else:
+        initial_q = float(initial_condition)
+        if not np.isfinite(initial_q):
+            raise ValueError("initial_condition must be 'steady', 'zero', or a finite number")
+
+    dQ = np.diff(q_obs, prepend=initial_q)
+    rho = 2.0 * alpha * beta / np.sqrt(kD)
+    cS = 1.0 / np.square(beta)
+    h_inf = 2.0 * k0(rho)
+
+    frac_step_max = float(pextra.get("frac_step_max", 0.95))
+    if not 0.0 < frac_step_max < 1.0:
+        raise ValueError(f"frac_step_max must be between 0 and 1, got {frac_step_max}")
+
+    k0_rho = k0(rho)
+    valid_k0 = np.isfinite(k0_rho) & (k0_rho > 0.0)
+    if valid_k0.any():
+        tmax_val = (
+            np.max(lambertw(1.0 / ((1.0 - frac_step_max) * k0_rho[valid_k0])).real)
+            * cS
+        )
+    else:
+        tmax_val = 0.0
+
+    tmax_days_cap = pextra.get("tmax_days_cap", None)
+    if tmax_days_cap is not None:
+        tmax_val = min(tmax_val, float(tmax_days_cap))
+    tmax_val = max(float(tmax_val), 0.0)
+
+    dt_lower = pextra.get("dt_lower", None)
+    if dt_lower is None:
+        dt_lower = infer_lower_timestep(index)
+    dt_lower_days = pd.Timedelta(dt_lower) / pd.Timedelta(1.0, unit="D")
+    if dt_lower_days <= 0.0:
+        raise ValueError(f"dt_lower must be positive, got {dt_lower}")
+
+    nt_max = min(max(int(np.ceil(tmax_val / dt_lower_days)) + 1, 1), nt)
 
     it_arr = np.arange(nt_max)[None, :] + np.arange(nt)[:, None]
     exclude = it_arr > (nt - 1)
     it_arr[exclude] = nt - 1
-    time_arr = (pextra["index"][it_arr] - pextra["index"][:, None]) / pd.Timedelta(1.0, unit="D")
+    time_arr = (index.to_numpy()[it_arr] - index.to_numpy()[:, None]) / pd.Timedelta(
+        1.0, unit="D"
+    )
 
-    # compute h for nt * nt_max
-    beta_arr = beta
-    # u_arr = r**2 * S / (4 * kD_arr * time_arr)
     tau_arr = np.log(
-        (2 / rho[it_arr] * beta_arr**2) * time_arr,
-        where=time_arr != 0,
+        (2.0 / rho[it_arr] * beta**2) * time_arr,
+        where=time_arr > 0.0,
         out=np.full_like(time_arr, fill_value=-10.0),
     )
-    # assert Wh goes to 1
-    dh, h_inf = Wh_approx(rho, tau_arr, it_arr=it_arr)
-    ds = dQ[:, None] / (4 * np.pi * kD[it_arr]) * dh
+    dh, _ = Wh_approx(rho, tau_arr, it_arr=it_arr)
+    dh[time_arr == 0.0] = 0.0
 
-    # transient
+    ds = dQ[:, None] / (4.0 * np.pi * kD[it_arr]) * dh
+
     ds_flipped = np.fliplr(ds)
-    drawdown = np.array([np.trace(ds_flipped, i) for i in np.arange(nt_max - 1, -nt + nt_max - 1, -1)])
+    drawdown = np.array(
+        [np.trace(ds_flipped, i) for i in np.arange(nt_max - 1, -nt + nt_max - 1, -1)]
+    )
 
-    # steady
-    drawdown[nt_max:] += np.cumsum(dQ)[: nt - nt_max] / (4 * np.pi * kD[nt_max:]) * h_inf[nt_max:]
+    if initial_q != 0.0:
+        drawdown += initial_q / (4.0 * np.pi * kD) * h_inf
+
+    if nt_max < nt:
+        steady_q = np.cumsum(dQ)[: nt - nt_max]
+        drawdown[nt_max:] += steady_q / (4.0 * np.pi * kD[nt_max:]) * h_inf[nt_max:]
 
     return drawdown
 
@@ -218,16 +459,23 @@ def Wh_approx(rho, tau, it_arr=None):
     -------
 
     """
+    tau = np.array(tau, copy=True)
     tau[tau > 100.0] = 100.0
     h_inf = k0(rho)
     expintrho = expint(rho)
-    w = (expintrho - h_inf) / (expintrho - expint(rho / 2))
-    I = (
+    denominator = expintrho - expint(rho / 2)
+    w = np.divide(
+        expintrho - h_inf,
+        denominator,
+        out=np.zeros_like(rho, dtype=float),
+        where=denominator != 0.0,
+    )
+    integral = (
         h_inf[it_arr]
         - w[it_arr] * expint(rho[it_arr] / 2 * np.exp(np.abs(tau)))
         + (w - 1)[it_arr] * expint(rho[it_arr] * np.cosh(tau))
     )
-    return h_inf[it_arr] + np.sign(tau) * I, 2 * h_inf
+    return h_inf[it_arr] + np.sign(tau) * integral, 2 * h_inf
 
 
 # def rain_exp(index, rainfall, rain_gain, rain_time_scale, **pextra):


### PR DESCRIPTION
## Summary
- correct WVP transient drawdown observations to use aquifer drawdown outside the filter
- build finite well-row geometry from `nput`, including corrected image-well distances and multiplicities
- convert pumping from m3/h to m3/d and add stricter validation for Hantush inputs, timestamps, initial conditions, and output shapes
- keep transient plots in a separate `Wvpweerstand_transient` results folder
- guard config rule selection against conflicting include/exclude filters

## Validation
- `python -m py_compile productiecapaciteit\src\strang_analyse_fun2.py productiecapaciteit\src\wvp_transient.py productiecapaciteit\src\wvp_transient_funs.py`
- synthetic geometry/transient checks for finite rows, image wells, and steady initial response
- `python -m ruff check --isolated productiecapaciteit\src\strang_analyse_fun2.py productiecapaciteit\src\wvp_transient.py productiecapaciteit\src\wvp_transient_funs.py`
- `python productiecapaciteit\src\wvp_transient.py`