### PR TITLE
Add explicit series-resistance head-loss term to the transient WVP report

### DIFF
--- a/productiecapaciteit/reports/report_wvpweerstand_transient.py
+++ b/productiecapaciteit/reports/report_wvpweerstand_transient.py
@@ -41,6 +41,7 @@ import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from scipy.integrate import cumulative_trapezoid
 from scipy.optimize import least_squares
 
 from productiecapaciteit import data_dir, plot_styles_dir, results_dir
@@ -86,6 +87,27 @@ DEFAULT_FIT_F_SCALE_M = 0.5
 MIN_TRANSIENT_OBSERVATIONS = 2
 DEFAULT_KD_REF_DATUM = pd.Timestamp("2020-01-01")
 
+# Series-resistance (clogging) head-loss term. The lumped infiltration + borehole-wall head
+# loss is a FIXED ~0.5 m at the reference high flow at the datum, and grows multiplicatively
+# with cumulative sanitized throughput:
+#     dp_series(t) = (dp_ref / Q_ref) * Q(t) * (1 + g * V(t))
+# where V(t) is the SIGNED cumulative volume from the datum (negative before, positive after),
+# so kD_ref stays the physical aquifer transmissivity (the baseline is explicit, not absorbed).
+# dp_ref (0.5 m), Q_ref (the 95th-percentile flow) and the datum are FIXED/known inputs; only
+# the growth rate g is fitted. g is bounded so that (1 + g*V) >= 0 over the record and, absent
+# pre-datum data, so the growth factor (1 + g*V) cannot exceed SERIES_MAX_GROWTH_FACTOR (the total
+# loss also carries the temperature viscosity factor).
+# dp_ref is a FIXED assumption (not fitted); if the true infiltration+borehole baseline differs,
+# kD_ref absorbs the difference. flow_ref defaults to 0.0 -- a "not yet calibrated" sentinel that
+# makes series_head_loss return 0 (the q_ref<=0 guard) until main sets it to the 95th-pct flow, so
+# a defaulted/legacy sheet applied without recalibration never adds a spurious baseline.
+DEFAULT_SERIES_DP_REF_M = 0.5
+DEFAULT_SERIES_FLOW_REF_M3_PER_H = 0.0
+DEFAULT_SERIES_DATUM = pd.Timestamp("2015-01-01")
+DEFAULT_SERIES_GROWTH_PER_M3 = 0.0
+SERIES_FLOW_REF_PERCENTILE = 95.0
+SERIES_MAX_GROWTH_FACTOR = 50.0
+
 RESULTS_SUBDIR = "Wvptweerstand"
 TRANSIENT_WORKBOOK = "Wvptweerstand_modelcoefficienten.xlsx"
 TRANSIENT_LOG = "Wvptweerstandcoefficient.log"
@@ -108,11 +130,20 @@ TRANSIENT_PHYSICAL_KEYS = (
     "storage_coefficient",
     "leakage_resistance_d",
 )
+# Series-resistance term. These are report-level coefficients: the ``.wvpt`` accessor (the pure
+# aquifer model) ignores them, so they only need to round-trip through the workbook.
+TRANSIENT_SERIES_KEYS = (
+    "series_dp_ref_m",
+    "series_flow_ref_m3_per_h",
+    "series_datum",
+    "series_growth_per_m3",
+)
 TRANSIENT_MODIFIED_KEY = "gewijzigd"
 TRANSIENT_COEFFICIENT_KEYS = (
     *TRANSIENT_REFERENCE_KEYS,
     *TRANSIENT_TEMPERATURE_KEYS,
     *TRANSIENT_PHYSICAL_KEYS,
+    *TRANSIENT_SERIES_KEYS,
     TRANSIENT_MODIFIED_KEY,
 )
 MODEL_FAILURE_EXCEPTIONS = (ValueError, RuntimeError, FloatingPointError, OverflowError)
@@ -185,6 +216,10 @@ def default_transient_coefficients(
     well_radius_m=DEFAULT_WELL_RADIUS_M,
     storage_coefficient=DEFAULT_STORAGE_COEFFICIENT,
     leakage_resistance_d=DEFAULT_LEAKAGE_RESISTANCE_D,
+    series_dp_ref_m=DEFAULT_SERIES_DP_REF_M,
+    series_flow_ref_m3_per_h=DEFAULT_SERIES_FLOW_REF_M3_PER_H,
+    series_datum=DEFAULT_SERIES_DATUM,
+    series_growth_per_m3=DEFAULT_SERIES_GROWTH_PER_M3,
 ):
     """Return default transient physical coefficients and fit metadata."""
     data = {
@@ -199,16 +234,37 @@ def default_transient_coefficients(
         "well_radius_m": float(well_radius_m),
         "storage_coefficient": float(storage_coefficient),
         "leakage_resistance_d": float(leakage_resistance_d),
+        "series_dp_ref_m": float(series_dp_ref_m),
+        "series_flow_ref_m3_per_h": float(series_flow_ref_m3_per_h),
+        "series_datum": pd.Timestamp(series_datum),
+        "series_growth_per_m3": float(series_growth_per_m3),
         TRANSIENT_MODIFIED_KEY: pd.Timestamp.now(),
     }
     return pd.Series(data)
 
 
 def normalize_transient_coefficients(coefficients):
-    """Ensure the coefficient Series carries a ``gewijzigd`` timestamp."""
+    """Ensure the coefficient Series carries a ``gewijzigd`` timestamp and the series-term keys.
+
+    Workbooks calibrated before the series term existed lack the ``series_*`` keys; inject their
+    defaults so old workbooks load and round-trip with the new keys added. The injected
+    ``series_flow_ref_m3_per_h`` default is 0, so an uncalibrated sheet adds no series head loss
+    (``main`` sets it to the 95th-pct flow before fitting; note growth 0 removes only the GROWTH,
+    the 0.5 m baseline remains once a real reference flow is set). Shared chokepoint that
+    :func:`transient_coefficients_from_sheet` (and thus every seeding path) calls.
+    """
     series = sheet_to_series(coefficients)
     if TRANSIENT_MODIFIED_KEY not in series.index:
         series.loc[TRANSIENT_MODIFIED_KEY] = pd.Timestamp.now()
+    series_defaults = {
+        "series_dp_ref_m": DEFAULT_SERIES_DP_REF_M,
+        "series_flow_ref_m3_per_h": DEFAULT_SERIES_FLOW_REF_M3_PER_H,
+        "series_datum": DEFAULT_SERIES_DATUM,
+        "series_growth_per_m3": DEFAULT_SERIES_GROWTH_PER_M3,
+    }
+    for key, default in series_defaults.items():
+        if key not in series.index:
+            series.loc[key] = default
     return series
 
 
@@ -234,11 +290,12 @@ def force_physical_constants(
     return out
 
 
-def with_transient_parameters(coefficients, kd_ref_m2_per_d, leakage_resistance_d):
-    """Return a coefficient Series with updated fitted parameters."""
+def with_transient_parameters(coefficients, kd_ref_m2_per_d, leakage_resistance_d, series_growth_per_m3):
+    """Return a coefficient Series with the three fitted parameters updated."""
     out = sheet_to_series(coefficients)
     out["kD_ref_m2_per_d"] = float(kd_ref_m2_per_d)
     out["leakage_resistance_d"] = float(leakage_resistance_d)
+    out["series_growth_per_m3"] = float(series_growth_per_m3)
     return out
 
 
@@ -269,14 +326,71 @@ def resample_transient_observations(df, frequency=RESAMPLE_FREQUENCY):
     return dfm
 
 
+def cumulative_extracted_volume_m3(flow_m3h, datum):
+    """SIGNED cumulative sanitized extracted volume [m3] relative to ``datum``.
+
+    ``flow_m3h`` is the total strang flow (m3/h) whose untrusted rows have already been set to
+    NaN by the ``get_false_measurements`` mask in :func:`load_observations`. Interior gaps are
+    time-interpolated so the integral has no holes; leading/trailing unknown flow is treated as
+    zero, and negative flow (non-physical for an extraction strang) is clipped to zero so the
+    raw cumulative is monotonic. The integral is rebased to zero at ``datum`` but NOT clipped, so
+    it is negative before the datum and positive after -- the clogging head loss was smaller than
+    its datum baseline in the past and grows afterwards.
+    """
+    q = flow_m3h.astype(float)
+    if not isinstance(q.index, pd.DatetimeIndex):
+        raise TypeError("flow_m3h must be indexed by a DatetimeIndex")
+    if not q.index.is_monotonic_increasing:
+        raise ValueError("flow_m3h index must be sorted ascending to integrate cumulative volume")
+    q = q.interpolate(method="time", limit_area="inside").fillna(0.0).clip(lower=0.0)
+    hours = (q.index - q.index[0]).total_seconds().to_numpy() / 3600.0
+    cumulative = cumulative_trapezoid(q.to_numpy(dtype=float), x=hours, initial=0.0)
+    datum_hours = (pd.Timestamp(datum) - q.index[0]).total_seconds() / 3600.0
+    cumulative = cumulative - np.interp(datum_hours, hours, cumulative)  # signed, zero at datum
+    return pd.Series(cumulative, index=q.index, name="cumulative_volume_m3")
+
+
+def series_head_loss(coefficients, dfm):
+    """Lumped infiltration + borehole-wall head loss [m], positive meters.
+
+    ``dp_series(t) = viscratio(T) * (dp_ref / Q_ref) * Q(t) * (1 + g * V(t))`` -- the fixed 0.5 m
+    baseline at the reference high flow AND reference temperature, scaled by the actual flow, grown
+    by the fitted rate ``g`` over the signed cumulative throughput ``V(t)``, and scaled by the
+    viscosity ratio for the modeled temperature. Returns zeros when the volume column is absent or
+    the reference flow is non-positive (the series term is then unidentifiable).
+    """
+    dp_ref = float(coefficients["series_dp_ref_m"])
+    q_ref = float(coefficients["series_flow_ref_m3_per_h"])
+    growth_rate = float(coefficients["series_growth_per_m3"])
+    if "cumulative_volume_m3" not in dfm or q_ref <= 0.0:
+        return pd.Series(0.0, index=dfm.index, name="series_head_loss")
+    volume = dfm["cumulative_volume_m3"].to_numpy(dtype=float)
+    flow = dfm["Q"].to_numpy(dtype=float)
+    growth = np.maximum(1.0 + growth_rate * volume, 0.0)  # positivity safety net
+    # A viscous series resistance scales with dynamic viscosity mu(T): multiply by the SAME
+    # viscosity ratio the aquifer kD uses (model_viscratio -- the report runs dp_model with
+    # temp_wvp=None, so both use the temperature model). dp_ref is defined at the reference
+    # temperature; the growth (1 + g*V) is a temperature-free geometric clogging term. Under
+    # temperature_method="Niet" viscratio == 1, so this is a bit-for-bit no-op there.
+    viscratio = coefficients.wvpt.model_viscratio(dfm.index).to_numpy(dtype=float)
+    return pd.Series(dp_ref / q_ref * flow * growth * viscratio, index=dfm.index, name="series_head_loss")
+
+
 def load_observations(
     strang,
     ci,
     df_a_filter,
     frequency=RESAMPLE_FREQUENCY,
     bad_data_rules=None,
+    series_datum=DEFAULT_SERIES_DATUM,
 ):
-    """Load, filter, reconstruct and resample observations for one strang."""
+    """Load, filter, reconstruct and resample observations for one strang.
+
+    Adds a ``cumulative_volume_m3`` column (signed sanitized cumulative throughput from
+    ``series_datum``) that drives the series-resistance growth. It is built at native resolution
+    from the get_false_measurements-masked flow -- BEFORE the resample drops rows -- then
+    interpolated onto the (dropped-row) model index so throughput during dropped intervals counts.
+    """
     df_fp = data_dir / "Merged" / f"{strang}.feather"
     df = pd.read_feather(df_fp)
     df["Datum"] = pd.to_datetime(df["Datum"])
@@ -291,7 +405,14 @@ def load_observations(
     )
     df.loc[untrusted_measurements, :] = np.nan
     df = reconstruct_aquifer_drawdown(df, ci, df_a_filter)
-    return resample_transient_observations(df, frequency=frequency)
+    volume_native = cumulative_extracted_volume_m3(df["Q"], datum=series_datum)
+    dfm = resample_transient_observations(df, frequency=frequency)
+    dfm["cumulative_volume_m3"] = np.interp(
+        dfm.index.astype("int64").to_numpy(),
+        df.index.astype("int64").to_numpy(),
+        volume_native.to_numpy(dtype=float),
+    )
+    return dfm
 
 
 # --------------------------------------------------------------------------- #
@@ -303,25 +424,27 @@ def transient_drawdown_for_coefficients(
     dfm,
     df_a_wvpt,
     ci,
+    series_growth_per_m3=0.0,
     target_well_index=None,
     initial_condition=FIT_INITIAL_CONDITION,
 ):
-    """Transient aquifer drawdown for a (kD_ref, leakage) pair, as positive meters."""
-    trial = with_transient_parameters(df_a_wvpt, kd_ref_m2_per_d, leakage_resistance_d)
-    return (
-        -trial.wvpt.dp_model(
-            dfm.index,
-            dfm.Q,
-            ci.nput,
-            ci.dx_tussenputten,
-            ci.r_mirrorwel,
-            target_well_index=target_well_index,
-            initial_condition=initial_condition,
-            # Observations are 12 h interval means labeled at the right edge
-            # (resample label="right"); apply each mean on the interval it covers.
-            flow_label="right",
-        )
-    ).rename("wvpt_drawdown")
+    """Modeled aquifer drawdown = leaky-aquifer Hantush + series head loss, as positive meters."""
+    trial = with_transient_parameters(
+        df_a_wvpt, kd_ref_m2_per_d, leakage_resistance_d, series_growth_per_m3
+    )
+    aquifer = -trial.wvpt.dp_model(
+        dfm.index,
+        dfm.Q,
+        ci.nput,
+        ci.dx_tussenputten,
+        ci.r_mirrorwel,
+        target_well_index=target_well_index,
+        initial_condition=initial_condition,
+        # Observations are 12 h interval means labeled at the right edge
+        # (resample label="right"); apply each mean on the interval it covers.
+        flow_label="right",
+    )
+    return (aquifer + series_head_loss(trial, dfm)).rename("wvpt_drawdown")
 
 
 def fit_transient_coefficients(  # noqa: C901
@@ -335,13 +458,21 @@ def fit_transient_coefficients(  # noqa: C901
     loss=DEFAULT_FIT_LOSS,
     f_scale=DEFAULT_FIT_F_SCALE_M,
 ):
-    """Fit ``kD_ref_m2_per_d`` and ``leakage_resistance_d`` in log space.
+    """Fit ``kD_ref_m2_per_d``, ``leakage_resistance_d`` and the series growth ``g``.
 
     The residual vector is (model - measured) drawdown at every finite
     observation, i.e. the measured drawdown *levels* are matched directly. The
     drawdown magnitude pins ``kD_ref`` and its dynamics pin the leakage ``c``;
     differencing the residuals would leave the two jointly unidentified. A robust
     ``loss``/``f_scale`` down-weights outliers and the zero-IC warm-up transient.
+
+    ``kD_ref`` and ``leakage`` are fitted in log space; the series growth ``g``
+    (``series_growth_per_m3``) is fitted in linear space. Because the series head loss is LINEAR
+    in ``g`` with a FIXED baseline, the joint fit is well-conditioned (no multimodality from the
+    clogging), unlike a kD-modifying term. ``g`` is bounded ``[0, g_upper]`` so that
+    ``(1 + g*V) >= 0`` over the record and, without pre-datum data, the growth factor ``(1 + g*V)``
+    cannot exceed ``SERIES_MAX_GROWTH_FACTOR`` (the total loss also carries the viscosity factor).
+    ``x_scale="jac"`` handles the tiny scale of ``g``.
     """
     kd_lower, kd_upper = np.asarray(kd_bounds_m2_per_d, dtype=float)
     leak_lower, leak_upper = np.asarray(leakage_bounds_d, dtype=float)
@@ -361,6 +492,22 @@ def fit_transient_coefficients(  # noqa: C901
     if not leak_lower <= leak0 <= leak_upper:
         msg = f"Initial leakage_resistance_d={leak0:g} outside bounds {tuple(leakage_bounds_d)}"
         raise ValueError(msg)
+
+    # Growth bounds (g >= 0, resistance only grows). Both are applied via the min(): positivity,
+    # (1 + g*V) >= 0 at the earliest/most-negative (pre-datum) point; and a growth cap,
+    # (1 + g*V) <= SERIES_MAX_GROWTH_FACTOR at the record end. The cap is the binding constraint
+    # only when there is no pre-datum data (v_min >= 0); otherwise the positivity bound is tighter.
+    if "cumulative_volume_m3" in dfm:
+        volume = dfm["cumulative_volume_m3"].to_numpy(dtype=float)
+        v_min, v_max = float(np.nanmin(volume)), float(np.nanmax(volume))
+    else:
+        v_min = v_max = 0.0
+    g_upper_pos = (1.0 / abs(v_min)) if v_min < 0.0 else np.inf
+    g_upper_cap = ((SERIES_MAX_GROWTH_FACTOR - 1.0) / v_max) if v_max > 0.0 else np.inf
+    g_upper = min(g_upper_pos, g_upper_cap)
+    if not np.isfinite(g_upper):
+        g_upper = np.finfo(float).tiny  # no throughput -> growth unidentifiable, pin g ~ 0
+    g0 = float(np.clip(float(df_a_wvpt["series_growth_per_m3"]), 0.0, g_upper))
 
     observed = dfm.drawdown_aquifer.to_numpy(dtype=float)
     valid = np.isfinite(observed)
@@ -389,8 +536,8 @@ def fit_transient_coefficients(  # noqa: C901
             return float(np.sum(np.where(z <= 1.0, z, 2.0 * np.sqrt(z) - 1.0)))
         return float(np.dot(residuals, residuals))
 
-    def evaluate(kd_ref, leakage):
-        key = (kd_ref, leakage)
+    def evaluate(kd_ref, leakage, growth):
+        key = (kd_ref, leakage, growth)
         if key in model_cache:
             return model_cache[key]
         try:
@@ -400,6 +547,7 @@ def fit_transient_coefficients(  # noqa: C901
                 dfm,
                 df_a_wvpt,
                 ci,
+                series_growth_per_m3=growth,
                 target_well_index=target_well_index,
                 initial_condition=initial_condition,
             )
@@ -410,8 +558,8 @@ def fit_transient_coefficients(  # noqa: C901
         model_cache[key] = (modeled, None)
         return model_cache[key]
 
-    def residual_values(kd_ref, leakage):
-        modeled, error = evaluate(kd_ref, leakage)
+    def residual_values(kd_ref, leakage, growth):
+        modeled, error = evaluate(kd_ref, leakage, growth)
         if error is not None:
             return np.full(n_resid, penalty, dtype=float)
         modeled_values = modeled.to_numpy(dtype=float)
@@ -420,18 +568,18 @@ def fit_transient_coefficients(  # noqa: C901
         residuals[good] = (modeled_values[valid] - observed[valid])[good]
         cost = rank_cost(residuals)
         if cost < best_fit["cost"]:
-            best_fit.update({"cost": cost, "params": (kd_ref, leakage), "modeled": modeled})
+            best_fit.update({"cost": cost, "params": (kd_ref, leakage, growth), "modeled": modeled})
         return residuals
 
     def feasible_start():
-        modeled, error = evaluate(kd0, leak0)
+        modeled, error = evaluate(kd0, leak0, g0)
         if error is None and np.isfinite(modeled.to_numpy(dtype=float)).any():
             return kd0, leak0
         kd_candidates = np.unique(np.r_[kd0, np.geomspace(kd_lower, kd_upper, num=7)])
         leak_candidates = np.unique(np.r_[leak0, np.geomspace(leak_lower, leak_upper, num=7)])
         for kd_candidate in kd_candidates:
             for leak_candidate in leak_candidates:
-                modeled, error = evaluate(float(kd_candidate), float(leak_candidate))
+                modeled, error = evaluate(float(kd_candidate), float(leak_candidate), g0)
                 if error is None and np.isfinite(modeled.to_numpy(dtype=float)).any():
                     return float(kd_candidate), float(leak_candidate)
         msg = (
@@ -443,20 +591,24 @@ def fit_transient_coefficients(  # noqa: C901
             msg = f"{msg}; last error: {last_model_error['message']}"
         raise RuntimeError(msg)
 
-    def residual(log_params):
-        kd_ref = float(np.exp(log_params[0]))
-        leakage = float(np.exp(log_params[1]))
-        return residual_values(kd_ref, leakage)
+    def residual(params):
+        kd_ref = float(np.exp(params[0]))
+        leakage = float(np.exp(params[1]))
+        growth = float(params[2])
+        return residual_values(kd_ref, leakage, growth)
 
     kd_start, leak_start = feasible_start()
 
     result = least_squares(
         residual,
-        x0=[np.log(kd_start), np.log(leak_start)],
+        x0=[np.log(kd_start), np.log(leak_start), g0],
         bounds=(
-            [np.log(kd_lower), np.log(leak_lower)],
-            [np.log(kd_upper), np.log(leak_upper)],
+            [np.log(kd_lower), np.log(leak_lower), 0.0],
+            [np.log(kd_upper), np.log(leak_upper), g_upper],
         ),
+        # Auto-scale from the Jacobian: the linear-space growth is orders of magnitude smaller
+        # than the O(1) log parameters, so a fixed x_scale would starve or overshoot it.
+        x_scale="jac",
         loss=loss,
         f_scale=f_scale,
         xtol=1e-8,
@@ -470,19 +622,20 @@ def fit_transient_coefficients(  # noqa: C901
 
     kd_ref = float(np.exp(result.x[0]))
     leakage = float(np.exp(result.x[1]))
+    growth = float(result.x[2])
     used_fallback = False
-    modeled, error = evaluate(kd_ref, leakage)
+    modeled, error = evaluate(kd_ref, leakage, growth)
     if error is not None:
         if best_fit["modeled"] is None:
             msg = "Optimizer ended at an infeasible parameter pair and no feasible candidate was evaluated"
             raise RuntimeError(msg) from error
         used_fallback = True
-        kd_ref, leakage = best_fit["params"]
+        kd_ref, leakage, growth = best_fit["params"]
         modeled = best_fit["modeled"]
 
     residuals = modeled.to_numpy(dtype=float) - observed
     coefficients = transient_coefficients_from_sheet(
-        with_transient_parameters(df_a_wvpt, kd_ref, leakage)
+        with_transient_parameters(df_a_wvpt, kd_ref, leakage, growth)
     )
     coefficients[TRANSIENT_MODIFIED_KEY] = pd.Timestamp.now()
 
@@ -539,12 +692,14 @@ def plot_fit(
     observed = dfm.drawdown_aquifer
     residuals = modeled_drawdown - observed
     innovations = residuals.diff()
+    series = series_head_loss(df_a_wvpt, dfm)
 
     fig, (ax0, ax1, ax2, ax3) = plt.subplots(4, 1, figsize=(12, 12), sharex=True)
     ax0.plot(observed.index, observed, c="C0", label="Gemeten", lw=0.8)
     ax0.plot(steady_drawdown.index, steady_drawdown, c="C1", label="Steady WVP model", lw=0.8)
     ax0.plot(modeled_drawdown.index, modeled_drawdown, c="C2", label="Transient WVP model", lw=0.8)
-    ax0.legend(loc=(0, 1), ncol=3)
+    ax0.plot(series.index, series, c="C6", label="Serieweerstand (infil.+boorgat)", lw=0.8)
+    ax0.legend(loc=(0, 1), ncol=4)
     ax0.set_ylabel("Drukverlies wvp bij gemeten Q (m)")
 
     ax1.axhline(0.0, c="black", lw=0.8)
@@ -570,7 +725,9 @@ def plot_fit(
     fig.suptitle(
         f"{strang}: nobs={dfm.index.size}, nput={multiwell_counts['nput']}, "
         f"kD_ref={df_a_wvpt['kD_ref_m2_per_d']:.4g} m2/d, "
-        f"leakage={df_a_wvpt['leakage_resistance_d']:.4g} d "
+        f"leakage={df_a_wvpt['leakage_resistance_d']:.4g} d, "
+        f"serie {df_a_wvpt['series_dp_ref_m']:.3g} m @ {df_a_wvpt['series_flow_ref_m3_per_h']:.3g} m3/h, "
+        f"groei={df_a_wvpt['series_growth_per_m3']:.3g}/m3 "
         f"(S={df_a_wvpt['storage_coefficient']:.3g}, r={df_a_wvpt['well_radius_m']:.3g} m), "
         f"mirror terms={multiwell_counts['self_mirrorwell_terms'] + multiwell_counts['neighbor_mirrorwell_terms']}"
     )
@@ -649,17 +806,28 @@ def main(strangen=None):
         try:
             source_sheet = source_sheets.get(strang, default_transient_coefficients())
             seed = force_physical_constants(transient_coefficients_from_sheet(source_sheet))
-            dfm = load_observations(strang, ci, filter_sheets[strang])
+            dfm = load_observations(
+                strang, ci, filter_sheets[strang], series_datum=seed["series_datum"]
+            )
+            # The reference "high flow" for the 0.5 m baseline is the 95th percentile of the
+            # sanitized flow, recomputed and stored each run.
+            seed["series_flow_ref_m3_per_h"] = float(
+                np.nanpercentile(dfm["Q"].to_numpy(dtype=float), SERIES_FLOW_REF_PERCENTILE)
+            )
             fit_result = fit_transient_coefficients(dfm, seed, ci)
             calibrated_sheets[strang] = transient_coefficients_from_sheet(fit_result["coefficients"])
             write_series_workbook(coefficient_fp, calibrated_sheets)
 
             coeff = calibrated_sheets[strang]
             report_logger.info(
-                "%s calibrated: kD_ref=%.4g m2/d, leakage=%.4g d (S=%.3g, r=%.3g m)",
+                "%s calibrated: kD_ref=%.4g m2/d, leakage=%.4g d, "
+                "serie=%.3g m @ %.4g m3/h, groei=%.3g /m3 (S=%.3g, r=%.3g m)",
                 strang,
                 coeff["kD_ref_m2_per_d"],
                 coeff["leakage_resistance_d"],
+                coeff["series_dp_ref_m"],
+                coeff["series_flow_ref_m3_per_h"],
+                coeff["series_growth_per_m3"],
                 coeff["storage_coefficient"],
                 coeff["well_radius_m"],
             )

--- a/tests/test_report_wvpweerstand_transient.py
+++ b/tests/test_report_wvpweerstand_transient.py
@@ -375,7 +375,7 @@ def test_main_forces_physical_constants_and_persists_calibrated_workbook(monkeyp
     monkeypatch.setattr(
         report,
         "load_observations",
-        lambda strang, ci, df_a_filter: pd.DataFrame(
+        lambda strang, ci, df_a_filter, **kwargs: pd.DataFrame(
             {"Q": [10.0, 10.0], "drawdown_aquifer": [1.0, 1.0]},
             index=index,
         ),
@@ -519,3 +519,423 @@ def test_main_seeds_from_modelcoefficienten_when_present(monkeypatch, tmp_path):
     report.main(["OK"])
 
     assert captured["seed_kd"] == pytest.approx(22.0)
+
+
+# --------------------------------------------------------------------------- #
+# Series-resistance head-loss term (infiltration + borehole wall)
+# --------------------------------------------------------------------------- #
+def _series_flow(index):
+    flow = np.zeros(index.size)
+    flow[5:25] = 12.0
+    flow[25:45] = 6.0
+    flow[45:65] = 16.0
+    flow[65:] = 9.0
+    return flow
+
+
+def _series_synthetic(true_kd=80.0, true_leakage=150.0, true_growth=1.0e-5):
+    # Aquifer + series head loss on an index that spans the 2015-01-01 datum (so V is signed).
+    ci = _ci()
+    index = pd.date_range("2014-06-01", periods=80, freq="10D")
+    flow = _series_flow(index)
+    volume = report.cumulative_extracted_volume_m3(
+        pd.Series(flow, index=index), datum=pd.Timestamp("2015-01-01")
+    ).to_numpy()
+    q95 = float(np.nanpercentile(flow, report.SERIES_FLOW_REF_PERCENTILE))
+    truth = default_transient_coefficients(
+        kd_ref_m2_per_d=true_kd,
+        leakage_resistance_d=true_leakage,
+        series_flow_ref_m3_per_h=q95,
+        series_growth_per_m3=true_growth,
+    )
+    dft = pd.DataFrame({"Q": flow, "cumulative_volume_m3": volume}, index=index)
+    observed = transient_drawdown_for_coefficients(
+        true_kd, true_leakage, dft, truth, ci, series_growth_per_m3=true_growth
+    )
+    dfm = pd.DataFrame(
+        {"Q": flow, "drawdown_aquifer": observed.to_numpy(dtype=float), "cumulative_volume_m3": volume},
+        index=index,
+    )
+    return dfm, truth, ci, q95
+
+
+def test_default_coefficients_include_series_keys():
+    coeff = default_transient_coefficients()
+
+    assert coeff["series_dp_ref_m"] == pytest.approx(report.DEFAULT_SERIES_DP_REF_M)
+    assert pd.Timestamp(coeff["series_datum"]) == report.DEFAULT_SERIES_DATUM
+    assert coeff["series_growth_per_m3"] == pytest.approx(0.0)
+    assert set(report.TRANSIENT_SERIES_KEYS) <= set(coeff.index)
+
+
+def test_cumulative_extracted_volume_is_signed_around_datum():
+    index = pd.date_range("2014-06-01", periods=14, freq="30D")  # straddles 2015-01-01
+    flow = pd.Series(np.full(index.size, 10.0), index=index)
+    datum = pd.Timestamp("2015-01-01")
+
+    v = report.cumulative_extracted_volume_m3(flow, datum=datum)
+
+    # Signed: negative before the datum, positive after, strictly increasing, zero at the datum.
+    assert v[v.index < datum].max() < 0.0
+    assert v[v.index > datum].min() > 0.0
+    assert np.all(np.diff(v.to_numpy()) > 0.0)
+    hours = (index - index[0]).total_seconds().to_numpy() / 3600.0
+    datum_hours = (datum - index[0]).total_seconds() / 3600.0
+    assert np.interp(datum_hours, hours, v.to_numpy()) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_series_head_loss_matches_formula_and_baseline_at_datum():
+    index = pd.date_range("2014-06-01", periods=8, freq="30D")
+    flow = np.full(index.size, 10.0)
+    volume = np.linspace(-1.0e5, 1.0e5, index.size)
+    coeff = default_transient_coefficients(
+        series_dp_ref_m=0.5, series_flow_ref_m3_per_h=16.0, series_growth_per_m3=1.0e-5
+    )
+    dfm = pd.DataFrame({"Q": flow, "cumulative_volume_m3": volume}, index=index)
+
+    hl = report.series_head_loss(coeff, dfm)
+
+    expected = 0.5 / 16.0 * flow * (1.0 + 1.0e-5 * volume)
+    np.testing.assert_allclose(hl.to_numpy(), expected, rtol=1e-12)
+    # At the datum (V=0) and the reference flow the loss is exactly the 0.5 m baseline.
+    at_datum = pd.DataFrame({"Q": [16.0], "cumulative_volume_m3": [0.0]}, index=index[:1])
+    assert float(report.series_head_loss(coeff, at_datum).iloc[0]) == pytest.approx(0.5)
+
+
+def test_series_head_loss_is_zero_without_volume_or_flow_ref():
+    index = pd.date_range("2015-01-01", periods=3, freq="D")
+    coeff = default_transient_coefficients(series_flow_ref_m3_per_h=16.0, series_growth_per_m3=1.0e-5)
+    no_volume = pd.DataFrame({"Q": [1.0, 2.0, 3.0]}, index=index)
+    np.testing.assert_allclose(report.series_head_loss(coeff, no_volume).to_numpy(), 0.0)
+
+    coeff0 = default_transient_coefficients(series_flow_ref_m3_per_h=0.0, series_growth_per_m3=1.0e-5)
+    dfm = pd.DataFrame({"Q": [1.0, 2.0, 3.0], "cumulative_volume_m3": [0.0, 1e4, 2e4]}, index=index)
+    np.testing.assert_allclose(report.series_head_loss(coeff0, dfm).to_numpy(), 0.0)
+
+    # The guard short-circuits BEFORE the viscosity factor, even with temperature active.
+    coeff_sin = default_transient_coefficients(
+        series_flow_ref_m3_per_h=0.0, temperature_method="sin", temperature_delta_degc=8.0
+    )
+    np.testing.assert_allclose(report.series_head_loss(coeff_sin, dfm).to_numpy(), 0.0)
+
+
+def test_series_head_loss_clips_negative_growth_factor():
+    # A growth large enough to drive (1 + g*V) negative before the datum is clipped at 0.
+    index = pd.date_range("2015-01-01", periods=3, freq="D")
+    coeff = default_transient_coefficients(
+        series_dp_ref_m=0.5, series_flow_ref_m3_per_h=10.0, series_growth_per_m3=1.0e-3
+    )
+    dfm = pd.DataFrame({"Q": [10.0, 10.0, 10.0], "cumulative_volume_m3": [-5000.0, 0.0, 5000.0]}, index=index)
+
+    hl = report.series_head_loss(coeff, dfm).to_numpy()
+
+    assert hl[0] == pytest.approx(0.0)  # 1 + 1e-3*(-5000) = -4 -> clipped
+    assert np.all(hl >= 0.0)
+
+
+def test_fit_recovers_series_growth():
+    true_kd, true_leakage, true_growth = 80.0, 150.0, 1.0e-5
+    dfm, truth, ci, _ = _series_synthetic(true_kd, true_leakage, true_growth)
+    seed = truth.copy()
+    seed["kD_ref_m2_per_d"] = report.DEFAULT_KD_REF_M2_PER_D
+    seed["leakage_resistance_d"] = report.DEFAULT_LEAKAGE_RESISTANCE_D
+    seed["series_growth_per_m3"] = 0.0  # start at no-growth and climb
+
+    result = fit_transient_coefficients(dfm, seed, ci)
+
+    coeff = result["coefficients"]
+    assert coeff["kD_ref_m2_per_d"] == pytest.approx(true_kd, rel=0.05)
+    assert coeff["leakage_resistance_d"] == pytest.approx(true_leakage, rel=0.1)
+    assert coeff["series_growth_per_m3"] == pytest.approx(true_growth, rel=0.1)
+    assert result["optimizer_result"].success is True
+    assert result["residuals"].abs().max() < 1e-2
+
+
+def test_fit_growth_defaults_to_zero_without_throughput():
+    # No cumulative_volume_m3 column -> the growth is unidentifiable and stays at 0.
+    ci = _ci()
+    index = pd.date_range("2020-01-01", periods=30, freq="D")
+    flow = np.zeros(index.size)
+    flow[5:] = 10.0
+    truth = default_transient_coefficients(kd_ref_m2_per_d=80.0, leakage_resistance_d=150.0)
+    observed = transient_drawdown_for_coefficients(
+        80.0, 150.0, pd.DataFrame({"Q": flow}, index=index), truth, ci
+    )
+    dfm = pd.DataFrame({"Q": flow, "drawdown_aquifer": observed.to_numpy(dtype=float)}, index=index)
+    seed = truth.copy()
+    seed["kD_ref_m2_per_d"] = 150.0
+    seed["leakage_resistance_d"] = 400.0
+
+    result = fit_transient_coefficients(dfm, seed, ci)
+
+    assert result["coefficients"]["series_growth_per_m3"] == pytest.approx(0.0, abs=1e-12)
+    assert result["coefficients"]["kD_ref_m2_per_d"] == pytest.approx(80.0, rel=0.1)
+
+
+def test_transient_coefficients_from_sheet_injects_series_defaults_for_old_sheet():
+    sheet = default_transient_coefficients()
+    old = sheet.drop(list(report.TRANSIENT_SERIES_KEYS))
+
+    restored = transient_coefficients_from_sheet(old)
+
+    assert restored["series_dp_ref_m"] == pytest.approx(report.DEFAULT_SERIES_DP_REF_M)
+    assert restored["series_growth_per_m3"] == pytest.approx(report.DEFAULT_SERIES_GROWTH_PER_M3)
+    assert pd.Timestamp(restored["series_datum"]) == report.DEFAULT_SERIES_DATUM
+
+
+def test_series_params_roundtrip_through_workbook(tmp_path):
+    workbook = tmp_path / report.TRANSIENT_WORKBOOK
+    sheet = default_transient_coefficients(
+        series_dp_ref_m=0.5,
+        series_flow_ref_m3_per_h=42.0,
+        series_datum=pd.Timestamp("2015-01-01"),
+        series_growth_per_m3=7.0e-6,
+    )
+
+    write_series_workbook(workbook, {"Q100": sheet})
+    actual = read_series_workbook(workbook)["Q100"]
+
+    assert actual["series_flow_ref_m3_per_h"] == pytest.approx(42.0)
+    assert actual["series_growth_per_m3"] == pytest.approx(7.0e-6)
+    assert pd.Timestamp(actual["series_datum"]) == pd.Timestamp("2015-01-01")
+
+
+def test_main_computes_q95_and_persists_series_growth(monkeypatch, tmp_path):
+    # End-to-end: main -> load_observations (datum threaded) -> Q_95 computed -> REAL fit ->
+    # workbook keeps a nonzero growth and the 95th-percentile reference flow.
+    dfm, _truth, _ci_unused, q95 = _series_synthetic(true_kd=80.0, true_leakage=150.0, true_growth=1.0e-5)
+    config = pd.DataFrame({"nput": [1], "dx_tussenputten": [15.0], "r_mirrorwel": [[]]}, index=["OK"])
+    _patch_main_environment(monkeypatch, tmp_path, config)
+    _write_filter_workbook(tmp_path, ["OK"])
+    transient_dir = tmp_path / report.RESULTS_SUBDIR
+    transient_dir.mkdir()
+    write_series_workbook(
+        transient_dir / report.TRANSIENT_WORKBOOK,
+        {"OK": default_transient_coefficients(kd_ref_m2_per_d=100.0, leakage_resistance_d=200.0)},
+    )
+
+    captured = {}
+
+    def stub_load(strang, ci, df_a_filter, **kwargs):
+        captured["datum"] = kwargs.get("series_datum")
+        return dfm.copy()
+
+    monkeypatch.setattr(report, "load_observations", stub_load)
+
+    report.main(["OK"])
+
+    assert captured["datum"] == report.DEFAULT_SERIES_DATUM
+    actual = read_series_workbook(transient_dir / report.TRANSIENT_WORKBOOK)["OK"]
+    assert actual["series_flow_ref_m3_per_h"] == pytest.approx(q95, rel=1e-6)
+    assert actual["series_growth_per_m3"] > 0.0
+    assert actual["series_growth_per_m3"] == pytest.approx(1.0e-5, rel=0.15)
+
+
+def test_series_baseline_present_at_zero_growth():
+    # g=0 removes only the GROWTH; the fixed 0.5 m baseline (dp_ref/Q_ref * Q) remains whenever a
+    # volume column and a positive reference flow are present. Guards a "g==0 => no clogging"
+    # short-circuit that would silently drop the baseline for every freshly-seeded strang.
+    ci = _ci()
+    index = pd.date_range("2015-01-01", periods=20, freq="10D")
+    flow = np.full(index.size, 12.0)
+    volume = np.linspace(0.0, 5.0e4, index.size)
+    coeff = default_transient_coefficients(
+        series_dp_ref_m=0.5, series_flow_ref_m3_per_h=16.0, series_growth_per_m3=0.0
+    )
+    dfm = pd.DataFrame({"Q": flow, "cumulative_volume_m3": volume}, index=index)
+
+    hl = report.series_head_loss(coeff, dfm)
+    np.testing.assert_allclose(hl.to_numpy(), 0.5 / 16.0 * flow, rtol=1e-12)
+    assert np.all(hl.to_numpy() > 0.0)
+
+    # The integrated model with the baseline exceeds the volume-less model by exactly the baseline.
+    with_baseline = transient_drawdown_for_coefficients(80.0, 150.0, dfm, coeff, ci)
+    no_series = transient_drawdown_for_coefficients(
+        80.0, 150.0, pd.DataFrame({"Q": flow}, index=index), coeff, ci
+    )
+    np.testing.assert_allclose(
+        (with_baseline - no_series).to_numpy(), 0.5 / 16.0 * flow, rtol=1e-10
+    )
+
+
+def test_fit_rails_growth_to_positivity_bound():
+    # Data that want more growth than positivity allows: g must rail to g_upper = 1/|V_min|
+    # (the positivity bound), not run away -- catches g_upper_pos -> inf.
+    ci = _ci()
+    index = pd.date_range("2014-06-01", periods=80, freq="10D")
+    flow = _series_flow(index)
+    volume = report.cumulative_extracted_volume_m3(
+        pd.Series(flow, index=index), datum=pd.Timestamp("2015-01-01")
+    ).to_numpy()
+    q95 = float(np.nanpercentile(flow, report.SERIES_FLOW_REF_PERCENTILE))
+    g_upper_pos = 1.0 / abs(float(volume.min()))
+    g_upper_cap = (report.SERIES_MAX_GROWTH_FACTOR - 1.0) / float(volume.max())
+    assert g_upper_pos < g_upper_cap  # positivity is the binding bound here
+    infeasible_growth = 5.0 * g_upper_pos
+
+    truth = default_transient_coefficients(
+        kd_ref_m2_per_d=80.0, leakage_resistance_d=150.0,
+        series_flow_ref_m3_per_h=q95, series_growth_per_m3=infeasible_growth,
+    )
+    dft = pd.DataFrame({"Q": flow, "cumulative_volume_m3": volume}, index=index)
+    observed = transient_drawdown_for_coefficients(
+        80.0, 150.0, dft, truth, ci, series_growth_per_m3=infeasible_growth
+    )
+    dfm = pd.DataFrame(
+        {"Q": flow, "drawdown_aquifer": observed.to_numpy(dtype=float), "cumulative_volume_m3": volume},
+        index=index,
+    )
+    seed = truth.copy()
+    seed["series_growth_per_m3"] = 0.0
+
+    result = fit_transient_coefficients(dfm, seed, ci)
+
+    fitted_g = result["coefficients"]["series_growth_per_m3"]
+    assert fitted_g <= g_upper_pos * (1.0 + 1e-9)  # never exceeds the positivity bound
+    assert fitted_g == pytest.approx(g_upper_pos, rel=0.1)  # railed to it
+
+
+def test_load_observations_aligns_signed_volume_onto_model_index(monkeypatch):
+    # The signed cumulative volume is built on the native masked flow BEFORE the resample and
+    # interpolated onto the dropped-row model index -- so throughput during dropped intervals still
+    # counts. Catches zeroing the alignment (which no other test reaches).
+    index = pd.date_range("2015-01-01", periods=60, freq="h")
+    flow = np.full(index.size, 10.0)
+    raw = pd.DataFrame(
+        {
+            "Datum": index,
+            "Q": flow,
+            "gws0": np.zeros(index.size),
+            "gws1": np.full(index.size, -2.0),
+            "pandpeil": np.zeros(index.size),
+        }
+    )
+    # A mid-record block with non-positive aquifer drawdown -> dropped by the resample mask.
+    raw.loc[20:30, "pandpeil"] = -5.0
+    monkeypatch.setattr(report.pd, "read_feather", lambda fp: raw.copy())
+    monkeypatch.setattr(report, "get_false_measurements", lambda *a, **k: np.zeros(index.size, dtype=bool))
+
+    dfm = report.load_observations(
+        "Q100", _ci(), _filter_coefficients(), series_datum=pd.Timestamp("2015-01-01")
+    )
+
+    native = report.cumulative_extracted_volume_m3(
+        pd.Series(flow, index=index), datum=pd.Timestamp("2015-01-01")
+    )
+    expected = np.interp(
+        dfm.index.astype("int64").to_numpy(),
+        index.astype("int64").to_numpy(),
+        native.to_numpy(dtype=float),
+    )
+    np.testing.assert_allclose(dfm["cumulative_volume_m3"].to_numpy(), expected, rtol=1e-9)
+    assert np.all(np.diff(dfm["cumulative_volume_m3"].to_numpy()) > 0.0)  # counts dropped throughput
+
+
+def test_cumulative_extracted_volume_constant_flow_magnitude():
+    index = pd.date_range("2015-01-01", periods=5, freq="D")
+    q = 10.0
+    v = report.cumulative_extracted_volume_m3(pd.Series(np.full(index.size, q), index=index), datum=index[0])
+    hours = (index - index[0]).total_seconds().to_numpy() / 3600.0
+    np.testing.assert_allclose(v.to_numpy(), q * hours, rtol=0.0, atol=1e-9)  # datum=start -> V=q*hours
+
+
+def test_cumulative_extracted_volume_clips_negative_flow():
+    index = pd.date_range("2015-01-01", periods=4, freq="D")
+    flow = pd.Series([10.0, -50.0, 10.0, 10.0], index=index)
+    v = report.cumulative_extracted_volume_m3(flow, datum=index[0])
+    assert np.all(np.diff(v.to_numpy()) >= 0.0)  # negative flow clipped -> monotonic
+
+
+def test_cumulative_extracted_volume_rejects_unsorted_index():
+    index = pd.DatetimeIndex(["2015-01-03", "2015-01-01", "2015-01-02", "2015-01-04"])
+    with pytest.raises(ValueError, match="sorted"):
+        report.cumulative_extracted_volume_m3(pd.Series(np.full(4, 10.0), index=index), datum=index.min())
+
+
+def test_cumulative_extracted_volume_rejects_non_datetime_index():
+    with pytest.raises(TypeError, match="DatetimeIndex"):
+        report.cumulative_extracted_volume_m3(pd.Series([1.0, 2.0, 3.0]), datum=pd.Timestamp("2015-01-01"))
+
+
+def _series_temperature_coefficients(**overrides):
+    # method="sin" with a seasonal amplitude -> a TIME-VARYING viscosity ratio (!= 1), so the
+    # element-wise multiply cannot be faked by a scalar broadcast.
+    kwargs = dict(
+        series_dp_ref_m=0.5,
+        series_flow_ref_m3_per_h=16.0,
+        series_growth_per_m3=2.0e-5,
+        temperature_method="sin",
+        temperature_mean_degc=12.0,
+        temperature_delta_degc=8.0,
+        temperature_ref_degc=12.0,
+    )
+    kwargs.update(overrides)
+    return default_transient_coefficients(**kwargs)
+
+
+def _positive_series_dfm(index):
+    # Strictly positive flow and strictly positive growth factor (1 + g*V > 0), so the series head
+    # loss is never 0 and ratios are well-posed.
+    flow = np.full(index.size, 12.0)
+    volume = np.linspace(-2.0e4, 8.0e4, index.size)  # 1 + 2e-5*V in [0.6, 2.6]
+    return pd.DataFrame({"Q": flow, "cumulative_volume_m3": volume}, index=index)
+
+
+def test_series_head_loss_scales_with_temperature_viscosity():
+    # dp_series == (dp_ref/Q_ref)*Q*(1+g*V) * model_viscratio(index), element-wise, with a
+    # time-varying viscratio. Kills: not-applied, inverse-direction, baseline-only, and
+    # collapse-to-scalar/broadcast.
+    index = pd.date_range("2015-01-01", periods=24, freq="15D")  # ~1 yr -> seasonal viscratio
+    coeff = _series_temperature_coefficients()
+    dfm = _positive_series_dfm(index)
+
+    viscratio = coeff.wvpt.model_viscratio(index).to_numpy(dtype=float)
+    assert viscratio.min() < 0.98 and viscratio.max() > 1.02  # genuinely time-varying, != 1
+
+    flow = dfm["Q"].to_numpy(dtype=float)
+    volume = dfm["cumulative_volume_m3"].to_numpy(dtype=float)
+    expected = 0.5 / 16.0 * flow * (1.0 + 2.0e-5 * volume) * viscratio
+    np.testing.assert_allclose(report.series_head_loss(coeff, dfm).to_numpy(), expected, rtol=1e-12)
+
+
+def test_series_and_aquifer_share_the_same_viscosity_factor():
+    # The series scaling factor equals the aquifer's kD viscosity factor (kD_ref_model/kD_model) --
+    # the physical rationale: the series stiffens with the SAME viscosity the aquifer uses.
+    index = pd.date_range("2015-01-01", periods=24, freq="15D")
+    coeff = _series_temperature_coefficients()
+    dfm = _positive_series_dfm(index)
+
+    flow = dfm["Q"].to_numpy(dtype=float)
+    volume = dfm["cumulative_volume_m3"].to_numpy(dtype=float)
+    reference_temp_series = 0.5 / 16.0 * flow * (1.0 + 2.0e-5 * volume)  # strictly > 0
+    aquifer_viscratio = (
+        coeff.wvpt.kD_ref_model(index) / coeff.wvpt.kD_model(index)
+    ).to_numpy(dtype=float)
+
+    series_factor = report.series_head_loss(coeff, dfm).to_numpy() / reference_temp_series
+    np.testing.assert_allclose(series_factor, aquifer_viscratio, rtol=1e-12)
+
+
+def test_series_contribution_through_pipeline_scales_with_temperature():
+    # Independent-truth analog of test_series_baseline_present_at_zero_growth, for sin + g != 0:
+    # through the FULL transient_drawdown_for_coefficients pipeline, the series contribution equals
+    # an INDEPENDENTLY built (dp_ref/Q_ref)*Q*(1+g*V)*model_viscratio. This catches drop/inverse
+    # viscratio -- which a self-referential fit test (truth and fit share series_head_loss) cannot,
+    # because the viscratio error cancels between the synthetic truth and the fitted model.
+    ci = _ci()
+    index = pd.date_range("2015-01-01", periods=24, freq="15D")
+    flow = np.full(index.size, 12.0)
+    volume = np.linspace(-2.0e4, 8.0e4, index.size)
+    g = 2.0e-5
+    coeff = _series_temperature_coefficients(series_growth_per_m3=g)  # dp_ref=0.5, q_ref=16, sin
+    dfm_with = pd.DataFrame({"Q": flow, "cumulative_volume_m3": volume}, index=index)
+    dfm_without = pd.DataFrame({"Q": flow}, index=index)  # no volume column -> no series term
+
+    # series_growth_per_m3=g must be passed (it overrides the coefficient growth); the aquifer part
+    # is identical between the two calls (same index, same Q), so their difference is the series term.
+    with_series = transient_drawdown_for_coefficients(80.0, 150.0, dfm_with, coeff, ci, series_growth_per_m3=g)
+    without_series = transient_drawdown_for_coefficients(80.0, 150.0, dfm_without, coeff, ci, series_growth_per_m3=g)
+
+    viscratio = coeff.wvpt.model_viscratio(index).to_numpy(dtype=float)
+    expected_series = 0.5 / 16.0 * flow * (1.0 + g * volume) * viscratio
+    np.testing.assert_allclose((with_series - without_series).to_numpy(), expected_series, rtol=1e-9)


### PR DESCRIPTION
Replaces the volume-driven kD reduction with an explicit additive **series-resistance head-loss** term, so `kD_ref` stays the physical aquifer transmissivity instead of absorbing the infiltration/borehole baseline:

```
dp_series(t) = viscratio(T) * (dp_ref / Q_ref) * Q(t) * (1 + g * V(t))
```

- **dp_ref** — fixed ~0.5 m baseline head loss at the reference (95th-percentile) flow and reference temperature at the datum (fixed assumption, not fitted).
- **V(t)** — cumulative extracted volume, signed about the datum.
- **series_growth_per_m3 (g)** — the fitted multiplicative clogging growth rate.

New coefficient keys `series_dp_ref_m` / `series_flow_ref_m3_per_h` / `series_datum` / `series_growth_per_m3` with backward-compatible defaults (reference flow defaults to `0` → legacy/uncalibrated sheets add no series head loss until recalibrated). Adds `cumulative_extracted_volume_m3` and `series_head_loss` helpers, threads `series_growth_per_m3` through the fit, and updates the report tests.

Local test suite: **121 passed**.

_Snapshot of the working-tree refactor, committed so CI (#6) can validate it. Base is unchanged `main`; refine the description as needed._